### PR TITLE
Fix broken function-call examples in docstrings

### DIFF
--- a/tradingeconomics/calendar.py
+++ b/tradingeconomics/calendar.py
@@ -391,7 +391,7 @@ def getCalendarEvents(
     -------
             getCalendarEvents(output_type='df')
             getCalendarEvents(country='china', output_type='df')
-            getCalendarEvents(country=['china', 'canada'] output_type='dict')
+            getCalendarEvents(country=['china', 'canada'], output_type='dict')
 
     """
 

--- a/tradingeconomics/financials.py
+++ b/tradingeconomics/financials.py
@@ -104,8 +104,8 @@ def getFinancialsCategoryList(output_type=None):
     Example
     -------
     If no argument is provided, returns a list of all categories as a dictionary.
-    getFinancialsCategories()
-    getFinancialsCategories(output_type='df')
+    getFinancialsCategoryList()
+    getFinancialsCategoryList(output_type='df')
     """
 
     d = {
@@ -139,7 +139,7 @@ def getFinancialsDataByCategory(category=None, output_type=None):
 
             or
 
-            getFinancialsDataCategory(symbol=['assets','debt'], output_type='df')
+            getFinancialsDataByCategory(category=['assets','debt'], output_type='df')
     """
 
     # d is a dictionary used for create the api url

--- a/tradingeconomics/historical.py
+++ b/tradingeconomics/historical.py
@@ -291,11 +291,11 @@ def getHistoricalByTicker(
 
     Example
     -------
-            getIndicatorByTicker(ticker = 'USURTOT', output_type = 'df')
+            getHistoricalByTicker(ticker = 'USURTOT', output_type = 'df')
 
-            getIndicatorByTicker(ticker = 'USURTOT', start_date = '2015-03-01', output_type = 'df')
+            getHistoricalByTicker(ticker = 'USURTOT', start_date = '2015-03-01', output_type = 'df')
 
-            getIndicatorByTicker(ticker = 'USURTOT', start_date = '2015-03-01', end_date='2015-09-30', output_type = 'df')
+            getHistoricalByTicker(ticker = 'USURTOT', start_date = '2015-03-01', end_date='2015-09-30', output_type = 'df')
     """
 
     # d is a dictionary used for create the api url

--- a/tradingeconomics/stock_splits.py
+++ b/tradingeconomics/stock_splits.py
@@ -40,7 +40,7 @@ def getStockSplits(
     --------
     getStockSplits(ticker = 'MMET', startDate='2023-09-01', endDate='2023-12-01')
     getStockSplits(ticker = ['MMET', 'REX'], startDate='2023-09-01')
-    getStockSplits(coutnry = ['Canada', 'United States'])
+    getStockSplits(country = ['Canada', 'United States'])
     getStockSplits()
 
     """


### PR DESCRIPTION
### Summary

Several docstring **Example** blocks ship code that fails if a user copies it verbatim — wrong function name, wrong keyword argument, or a syntax error. This PR corrects five such examples across four modules so they match the actual public API. No library/runtime code is changed.

### Fixes

| Module / function | Before | After |
|---|---|---|
| `calendar.getCalendarEvents` | `getCalendarEvents(country=['china', 'canada'] output_type='dict')` — missing comma → `SyntaxError` | adds the comma |
| `stock_splits.getStockSplits` | `getStockSplits(coutnry = [...])` → `TypeError` | `country = [...]` |
| `financials.getFinancialsCategoryList` | `getFinancialsCategories()` — function doesn't exist → `NameError` | `getFinancialsCategoryList()` |
| `financials.getFinancialsDataByCategory` | `getFinancialsDataCategory(symbol=[...])` — function doesn't exist and `symbol` isn't a parameter | `getFinancialsDataByCategory(category=[...])` |
| `historical.getHistoricalByTicker` | `getIndicatorByTicker(ticker=..., start_date=..., end_date=...)` — names a different function that doesn't accept those args | `getHistoricalByTicker(...)` |

### Verification

Each corrected example was checked against the real signatures (no API calls made):

```python
import ast, inspect, tradingeconomics as te
ast.parse("getCalendarEvents(country=['china','canada'], output_type='dict')")  # parses
inspect.signature(te.getFinancialsDataByCategory).bind_partial(category=['assets','debt'], output_type='df')
inspect.signature(te.getHistoricalByTicker).bind_partial(ticker='USURTOT', start_date='2015-03-01', end_date='2015-09-30', output_type='df')
assert not hasattr(te, "getFinancialsCategories")     # old example would have failed
assert not hasattr(te, "getFinancialsDataCategory")   # old example would have failed
```

All pass; the two old function names confirmed not to exist on the package.